### PR TITLE
Add Pydantic Collab to Pydantic-AI Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 - [pydantic-ai-todo](https://github.com/vstorm-co/pydantic-ai-todo) - Standalone task planning library for pydantic-ai agents. Provides `read_todos` and `write_todos` tools with flexible storage backends.
 - [pydantic-ai-filesystem-sandbox](https://github.com/zby/pydantic-ai-filesystem-sandbox) - Secure filesystem sandbox toolset with LLM-friendly errors. Provides sandboxing, read/write control, granular permissions, and human-in-the-loop approval workflows.
 - [pydantic-ai-skills](https://github.com/DougTrajano/pydantic-ai-skills) - Standardized framework for building and managing Agent Skills. Features progressive disclosure, type-safe design, multi-directory support, and Anthropic Agent Skills compatibility.
-- [pydantic-collab](https://github.com/boazkatzir/pydantic-collab/) - Multi-agent orchestration framework for building agent teams. Agents collaborate via handoffs, consultations (tool calls), and shared memory on top of pre-built and custom network topologies, Logfire observability included.
+- [pydantic-collab](https://github.com/boazkatzir/pydantic-collab) - Multi-agent orchestration framework for building agent teams. Agents collaborate via handoffs, consultations (tool calls), and shared memory on top of pre-built and custom network topologies, Logfire observability included.
 
 ## Templates & Boilerplates
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@
 - [pydantic-ai-todo](https://github.com/vstorm-co/pydantic-ai-todo) - Standalone task planning library for pydantic-ai agents. Provides `read_todos` and `write_todos` tools with flexible storage backends.
 - [pydantic-ai-filesystem-sandbox](https://github.com/zby/pydantic-ai-filesystem-sandbox) - Secure filesystem sandbox toolset with LLM-friendly errors. Provides sandboxing, read/write control, granular permissions, and human-in-the-loop approval workflows.
 - [pydantic-ai-skills](https://github.com/DougTrajano/pydantic-ai-skills) - Standardized framework for building and managing Agent Skills. Features progressive disclosure, type-safe design, multi-directory support, and Anthropic Agent Skills compatibility.
+- [pydantic-collab](https://github.com/boazkatzir/pydantic-collab/) - Multi-agent orchestration framework for building agent teams that collaborate via handoffs, consultations (tool calls), and shared memory. Features pre-built and custom network topologies and Logfire observability. 
 
 ## Templates & Boilerplates
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 - [pydantic-ai-todo](https://github.com/vstorm-co/pydantic-ai-todo) - Standalone task planning library for pydantic-ai agents. Provides `read_todos` and `write_todos` tools with flexible storage backends.
 - [pydantic-ai-filesystem-sandbox](https://github.com/zby/pydantic-ai-filesystem-sandbox) - Secure filesystem sandbox toolset with LLM-friendly errors. Provides sandboxing, read/write control, granular permissions, and human-in-the-loop approval workflows.
 - [pydantic-ai-skills](https://github.com/DougTrajano/pydantic-ai-skills) - Standardized framework for building and managing Agent Skills. Features progressive disclosure, type-safe design, multi-directory support, and Anthropic Agent Skills compatibility.
-- [pydantic-collab](https://github.com/boazkatzir/pydantic-collab/) - Multi-agent orchestration framework for building agent teams that collaborate via handoffs, consultations (tool calls), and shared memory. Features pre-built and custom network topologies and Logfire observability. 
+- [pydantic-collab](https://github.com/boazkatzir/pydantic-collab/) - Multi-agent orchestration framework for building agent teams. Agents collaborate via handoffs, consultations (tool calls), and shared memory on top of pre-built and custom network topologies, Logfire observability included.
 
 ## Templates & Boilerplates
 


### PR DESCRIPTION
## Changes
Added  [pydantic-collab](https://github.com/boazkatzir/pydantic-collab)  to Frameworks & Libraries section
### Summary
Added pydantic-collab, as it fits the criteria: 
- Actively maintained
- MIT license
- Based on pydantic-ai 
- README with clear instructions
- Works only as advertised.

## Summary line for project
Multi-agent orchestration framework for building agent teams. Agents collaborate via handoffs, consultations (tool calls), and shared memory on top of pre-built and custom network topologies, Logfire observability included.
