### PR TITLE
Add pai-agent-sdk to Frameworks & Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
 
 ## Frameworks & Libraries
 
+- [pai-agent-sdk](https://github.com/youware-labs/pai-agent-sdk) - Production-ready SDK for building AI agents with Pydantic AI. Provides full developer control without abstraction overhead, featuring environment-based architecture, resumable sessions, hierarchical subagents, and human-in-the-loop approval workflows.
 - [pydantic-deep](https://github.com/vstorm-co/pydantic-deepagents) - Python framework for building production-grade autonomous agents. Extends Pydantic AI with agent orchestration, task planning, subagent delegation, context management, and multiple backend support.
 - [pydantic-ai-middleware](https://github.com/vstorm-co/pydantic-ai-middleware) - Lightweight middleware library providing clean before/after hooks without imposed guardrail structure. Supports input/output processing, tool management, error handling, rate limiting, and audit logging.
 - [pydantic-ai-backend](https://github.com/vstorm-co/pydantic-ai-backend) - File storage, sandbox backends, and console toolset for pydantic-ai agents. Includes LocalBackend, StateBackend, DockerSandbox, and pre-configured Docker runtimes.


### PR DESCRIPTION
## Changes

### Summary

Add pai-agent-sdk to the Frameworks & Libraries section as a production-ready SDK for building AI agents with Pydantic AI.

### Business Context

pai-agent-sdk is a notable library in the Pydantic AI ecosystem that offers a different approach emphasizing full developer control without abstraction overhead, making it a valuable addition to this curated list.

### Changes

Added a new entry in `README.md` under Frameworks & Libraries:

```
- [pai-agent-sdk](https://github.com/youware-labs/pai-agent-sdk) - Production-ready SDK for building AI agents with Pydantic AI. Provides full developer control without abstraction overhead, featuring environment-based architecture, resumable sessions, hierarchical subagents, and human-in-the-loop approval workflows.
```

Key features highlighted:
- Full developer control without abstraction overhead
- Environment-based architecture
- Resumable sessions
- Hierarchical subagents
- Human-in-the-loop approval workflows

### Verification

1. Check the README renders correctly on GitHub
2. Verify the link https://github.com/youware-labs/pai-agent-sdk is accessible
3. Confirm the description accurately reflects the library's capabilities

### Linked Issues

N/A
