### PR TITLE
docs: add semantix-ai to Frameworks & Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@
 - [pydantic-ai-skills](https://github.com/DougTrajano/pydantic-ai-skills) - Standardized framework for building and managing Agent Skills. Features progressive disclosure, type-safe design, multi-directory support, and Anthropic Agent Skills compatibility.
 - [pydantic-ai-toolguard](https://github.com/stevenkozeniesky02/pydantic-ai-toolguard) - Deny-first tool authorization capability for pydantic-ai agents. Implements glob-based permission rules, parameter conditions, schedule windows, rate limiting, approval workflows, and append-only audit logging. Built on the AgentsID permission specification.
 - [pydantic-collab](https://github.com/boazkatzir/pydantic-collab) - Multi-agent orchestration framework for building agent teams. Agents collaborate via handoffs, consultations (tool calls), and shared memory on top of pre-built and custom network topologies, Logfire observability included.
+- [semantix-ai](https://github.com/labrat-akhona/semantix-ai) - Semantic output validation for Pydantic AI agents. Validates that LLM outputs match natural-language intents using local NLI inference (~15ms, no API key). Integrates with `output_validator` and `ModelRetry` for automatic self-correction.
 
 ## Templates & Boilerplates
 


### PR DESCRIPTION
## Summary

Adds [semantix-ai](https://github.com/labrat-akhona/semantix-ai) to the Frameworks & Libraries section.

semantix-ai provides semantic output validation for Pydantic AI agents — it validates that LLM outputs match natural-language intents using local NLI inference (~15ms per check, no API key needed). It integrates with Pydantic AI's `output_validator` and `ModelRetry` for automatic self-correction.

```python
from pydantic_ai import Agent
from semantix import Intent
from semantix.integrations.pydantic_ai import semantix_validator

class Polite(Intent):
    """The text must be polite and professional."""

agent = Agent('openai:gpt-5.2', output_type=str)
agent.output_validator(semantix_validator(Polite))
```

- **PyPI:** [pypi.org/project/semantix-ai](https://pypi.org/project/semantix-ai/)
- **231 tests**, MIT licensed