### PR TITLE
Add pydantic-ai-ejentum (Ejentum Reasoning Harness)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@
 - [pydantic-ai-toolguard](https://github.com/stevenkozeniesky02/pydantic-ai-toolguard) - Deny-first tool authorization capability for pydantic-ai agents. Implements glob-based permission rules, parameter conditions, schedule windows, rate limiting, approval workflows, and append-only audit logging. Built on the AgentsID permission specification.
 - [pydantic-collab](https://github.com/boazkatzir/pydantic-collab) - Multi-agent orchestration framework for building agent teams. Agents collaborate via handoffs, consultations (tool calls), and shared memory on top of pre-built and custom network topologies, Logfire observability included.
 - [semantix-ai](https://github.com/labrat-akhona/semantix-ai) - Semantic output validation for Pydantic AI agents. Validates that LLM outputs match natural-language intents using local NLI inference (~15ms, no API key). Integrates with `output_validator` and `ModelRetry` for automatic self-correction.
+- [pydantic-ai-ejentum](https://github.com/ejentum/pydantic-ai-ejentum) - PydanticAI Toolset wrapping the Ejentum Reasoning Harness. `EjentumToolset` subclasses `FunctionToolset` and registers four agent-callable tools (`harness_reasoning`, `harness_code`, `harness_anti_deception`, `harness_memory`). Each call returns a structured cognitive scaffold (named failure pattern, executable procedure, suppression vectors, falsification test) the model reads internally to shape its next response.
 
 ## Templates & Boilerplates
 


### PR DESCRIPTION
Adds `pydantic-ai-ejentum` under **Frameworks & Libraries**.

`pydantic-ai-ejentum` wraps the Ejentum Reasoning Harness as a `FunctionToolset` subclass. `EjentumToolset` registers four agent-callable tools (`harness_reasoning`, `harness_code`, `harness_anti_deception`, `harness_memory`). The agent calls one before generating; each call returns a structured cognitive scaffold (named failure pattern, executable procedure, suppression vectors, falsification test) that the model reads internally to shape its next response.

Meets the contributing criteria:
- Directly related to Pydantic AI (subclasses `FunctionToolset` from `pydantic_ai`)
- Solves a real problem (pre-generation cognitive scaffolds for analytical / planning / code / integrity-sensitive agent steps)
- Actively maintained (initial release today, OIDC trusted-publisher CI)
- README with install + usage examples
- Works as advertised (21/21 unit tests, Python 3.10/3.11/3.12 matrix)
- MIT license

Maintainer guidance on the framework's own issue tracker pointed the package toward their `docs/toolsets.md` Third-Party Toolsets section (PR pydantic/pydantic-ai#5594 is the docs-side companion). Filing here so PydanticAI users browsing this awesome list also find the package.

- PyPI: https://pypi.org/project/pydantic-ai-ejentum/
- Source: https://github.com/ejentum/pydantic-ai-ejentum