### PR TITLE
feat: add TWZRD Agent Intel MCP server (Solana x402 trust scoring)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@
 - [semantix-ai](https://github.com/labrat-akhona/semantix-ai) - Semantic output validation for Pydantic AI agents. Validates that LLM outputs match natural-language intents using local NLI inference (~15ms, no API key). Integrates with `output_validator` and `ModelRetry` for automatic self-correction.
 - [pydantic-ai-ejentum](https://github.com/ejentum/pydantic-ai-ejentum) - PydanticAI Toolset wrapping the Ejentum Reasoning Harness. `EjentumToolset` subclasses `FunctionToolset` and registers four agent-callable tools (`harness_reasoning`, `harness_code`, `harness_anti_deception`, `harness_memory`). Each call returns a structured cognitive scaffold (named failure pattern, executable procedure, suppression vectors, falsification test) the model reads internally to shape its next response.
 
+- [twzrd-agent-intel](https://github.com/twzrd-sol/twzrd-agent-intel) - Trust scoring and x402 payment verification MCP server for Pydantic AI agents operating on Solana. Exposes `resolve_agent`, `score_agent`, `preflight_check`, `verify_trust_receipt`, and `get_trust_receipt` tools via streamable-http. Zero-install: `{"mcpServers": {"twzrd-agent-intel": {"url": "https://intel.twzrd.xyz/mcp"}}}`.
+
 ## Templates & Boilerplates
 
 - [full-stack-fastapi-nextjs-llm-template](https://github.com/vstorm-co/full-stack-fastapi-nextjs-llm-template) - Production-ready project generator for AI/LLM applications. Combines FastAPI backend with Next.js 15 frontend, WebSocket streaming, JWT auth, multiple database options, and 20+ enterprise integrations.


### PR DESCRIPTION
## Summary

Adds [TWZRD Agent Intel](https://intel.twzrd.xyz) to the **Frameworks & Libraries** section.

**TWZRD Agent Intel** is a trust-scoring and x402 payment verification MCP server for agents operating in Solana's micropayment ecosystem:

- **Zero-install setup**: Streamable-HTTP transport — add the MCP config and tools are available immediately
- **Tools**: `resolve_agent` (score a Solana wallet), `preflight_check` (verify x402 readiness), `verify_trust_receipt` (validate proof of payment), `get_trust_receipt` (paid via x402)
- **Pydantic AI integration**: Use with `MCPServerHTTP` or `MCPClient` to verify counterparty trust before transacting
- **PyPI**: `pip install twzrd-agent-intel`
- **Config**: `{"mcpServers": {"twzrd-agent-intel": {"url": "https://intel.twzrd.xyz/mcp"}}}`

Fits naturally in Frameworks & Libraries as a domain-specific toolset extending Pydantic AI for Web3/payments use cases.