### PR TITLE
Add live web search guide to Examples & Tutorials

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@
 - [pydantic-ai-rlm](https://github.com/vstorm-co/pydantic-ai-rlm) - Recursive Language Models with Pydantic AI.
 - [Pydantic AI Walkthrough](https://colab.research.google.com/drive/12oZEM098SG2bYq0D1UGyW9YHKEbEkSNi?usp=sharing) - Interactive notebook covering agents, structured outputs, tool use, dependency injection, and building a Gradio chat UI with Pydantic AI. Created by [Nicolai Thomsen](https://www.linkedin.com/feed/update/urn:li:activity:7439395531006693376/?actorCompanyId=93077574).
 - [Pydantic AI: Build Type-Safe LLM Agents in Python](https://realpython.com/pydantic-ai/) - RealPython tutorial on creating language model agents with validated structured outputs, function calling, and dependency injection.
+- [Add live web search to a Pydantic AI agent](https://superhighway.walls.sh/guides/web-search-pydantic-ai) - Guide to adding live web search via MCPServerStdio (x402 pay-per-call wallet) or @agent.tool_plain REST tools with a free API key. Covers all five tools: web_search, news_search, image_search, scrape, research.
 
 ## Observability
 


### PR DESCRIPTION
## What

Adds [Add live web search to a Pydantic AI agent](https://superhighway.walls.sh/guides/web-search-pydantic-ai) to the Examples & Tutorials section.

## Why it's awesome

The guide covers two complete integration paths for adding live web search to a Pydantic AI agent:

1. **MCPServerStdio** — loads Superhighway's five search tools (web_search, news_search, image_search, scrape, research) via the MCP protocol. The agent pays per call in USDC via x402 — no API key, no human billing loop.
2. **@agent.tool_plain** — wraps the REST API as typed function tools using a free API key (1,000 calls/month). Demonstrates the `tool_plain` vs `tool` distinction with a working multi-tool example.

Superhighway is a live web search API specifically designed for AI agents — pay per call via x402 or use a free API key. The guide directly addresses "how do I add real-time web search to my Pydantic AI agent?" which is a common question in the community.

The guide is actively maintained and the service is live at superhighway.walls.sh.