### PR TITLE
Add fedotmas-harness project to Frameworks & Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@
 - [pydantic-collab](https://github.com/boazkatzir/pydantic-collab) - Multi-agent orchestration framework for building agent teams. Agents collaborate via handoffs, consultations (tool calls), and shared memory on top of pre-built and custom network topologies, Logfire observability included.
 - [semantix-ai](https://github.com/labrat-akhona/semantix-ai) - Semantic output validation for Pydantic AI agents. Validates that LLM outputs match natural-language intents using local NLI inference (~15ms, no API key). Integrates with `output_validator` and `ModelRetry` for automatic self-correction.
 - [pydantic-ai-ejentum](https://github.com/ejentum/pydantic-ai-ejentum) - PydanticAI Toolset wrapping the Ejentum Reasoning Harness. `EjentumToolset` subclasses `FunctionToolset` and registers four agent-callable tools (`harness_reasoning`, `harness_code`, `harness_anti_deception`, `harness_memory`). Each call returns a structured cognitive scaffold (named failure pattern, executable procedure, suppression vectors, falsification test) the model reads internally to shape its next response.
+- [fedotmas-harness](https://github.com/ITMO-NSS-Team/fedotmas-harness) - Orchestrates Pydantic AI agents into common multi-agent patterns with a tiny engine where any function or state machine is also an agent.
 
 ## Templates & Boilerplates
 


### PR DESCRIPTION
## What

Adds [fedotmas-harness](https://github.com/ITMO-NSS-team/fedotmas-harness) to the Frameworks & Libraries section.

## Why it's awesome

FEDOT.MAS is a tiny orchestration engine that composes Pydantic AI agents into multi-agent systems, reproducing the common MAS patterns: sequential, parallel, routing, loops, orchestrator–workers, blackboard, swarm, etc.

1. **Pydantic AI as the default backend.** The reference `PydanticAI` adapter is what the quickstart runs; binding any agent SDK is a single `complete(...)` method, so existing Pydantic AI agents drop in unchanged.
2. **Any node is an agent.** The engine is deliberately blind, which means a Pydantic AI agent, a plain async function, or a state machine are all the same kind of node, so you mix LLM reasoning and deterministic code uniformly.
3. **Systems as data.** A small JSON manifest language lets you write a whole multi-agent system declaratively and compile it to a runnable flow.

You can express practically any MAS pattern, combine patterns freely, and route between them dynamically. It also keeps the FastAPI-like developer experience of Pydantic AI, the stable default backend.