### PR TITLE
Add pydantic-ai-chdb to Frameworks & Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@
 - [semantix-ai](https://github.com/labrat-akhona/semantix-ai) - Semantic output validation for Pydantic AI agents. Validates that LLM outputs match natural-language intents using local NLI inference (~15ms, no API key). Integrates with `output_validator` and `ModelRetry` for automatic self-correction.
 - [pydantic-ai-ejentum](https://github.com/ejentum/pydantic-ai-ejentum) - PydanticAI Toolset wrapping the Ejentum Reasoning Harness. `EjentumToolset` subclasses `FunctionToolset` and registers four agent-callable tools (`harness_reasoning`, `harness_code`, `harness_anti_deception`, `harness_memory`). Each call returns a structured cognitive scaffold (named failure pattern, executable procedure, suppression vectors, falsification test) the model reads internally to shape its next response.
 - [fedotmas-harness](https://github.com/ITMO-NSS-Team/fedotmas-harness) - Orchestrates Pydantic AI agents into common multi-agent patterns with a tiny engine where any function or state machine is also an agent.
+- [pydantic-ai-chdb](https://github.com/chdb-io/pydantic-ai-chdb) - Analytical SQL capability backed by chDB, the in-process ClickHouse engine. `ChDBCapability` registers query and schema-discovery tools over local files (Parquet/CSV/JSON), object storage, and remote databases — no server or credentials, engine-level read-only default, and typed engine errors mapped to `ModelRetry` for automatic self-correction. Listed under Third-Party Capabilities in the official Pydantic AI docs.
 
 ## Templates & Boilerplates
 


### PR DESCRIPTION
Adds [pydantic-ai-chdb](https://github.com/chdb-io/pydantic-ai-chdb) — an analytical SQL capability backed by [chDB](https://github.com/chdb-io/chdb), the in-process ClickHouse engine, maintained by the chDB team at ClickHouse.

Why it's awesome:
- Gives agents SQL over Parquet/CSV/JSON files, S3, and remote databases with zero setup — the engine runs inside the Python process, no server or credentials.
- Engine-level safety rather than prompt-level: sessions default to ClickHouse `readonly=2`, results are capped with an explicit `truncated` flag.
- Typed engine errors map to `ModelRetry` via the `on_tool_execute_error` hook, so the model reads e.g. `chDB UNKNOWN_IDENTIFIER (code 47): …` and corrects its own SQL.
- Follows the official capability-publishing guide (`pydantic-ai-` prefix, `Agent.from_spec` support) and was recently merged into Pydantic AI's [Third-Party Capabilities docs](https://github.com/pydantic/pydantic-ai/pull/6467).
- Apache-2.0, tested (offline `FunctionModel` agent runs including the error-to-retry path), on [PyPI](https://pypi.org/project/pydantic-ai-chdb/).

Format follows the section's existing entries; appended at the end.